### PR TITLE
Add quiz question count selector

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,3 +1,4 @@
+if (typeof window !== 'undefined') {
     // Slide panel data
     const panelData = {
       "t-test": {
@@ -135,8 +136,14 @@
     }
     // QUIZ ENGINE
     // questionPool được nạp từ questions.js
-    // Lấy ngẫu nhiên 20 câu, shuffle đáp án
+    // Lấy ngẫu nhiên N câu (tùy chọn), shuffle đáp án
     let quizQuestions = [];
+    let questionCount = 20;
+
+    function updateQuestionCount() {
+      const sel = document.getElementById('question-count');
+      if (sel) questionCount = parseInt(sel.value, 10) || 20;
+    }
     function shuffleArray(arr) {
       for (let i = arr.length - 1; i > 0; i--) {
         const j = Math.floor(Math.random() * (i + 1));
@@ -145,9 +152,10 @@
     }
     function generateQuiz() {
       quizQuestions = [];
+      updateQuestionCount();
       const indexes = Array.from(Array(questionPool.length).keys());
       shuffleArray(indexes);
-      const picked = indexes.slice(0, 20);
+      const picked = indexes.slice(0, questionCount);
       picked.forEach(i => {
         let q = questionPool[i];
         let opts = q.opts.slice();
@@ -197,17 +205,18 @@
         }
       });
       document.getElementById('quiz-score').innerHTML =
-        `<div style="font-weight:700; font-size:1.2em; margin:16px 0;">Bạn đúng ${score}/20 câu.</div>`;
+        `<div style="font-weight:700; font-size:1.2em; margin:16px 0;">Bạn đúng ${score}/${questionCount} câu.</div>`;
       window.quizSubmitted = true;
     }
-    function resetQuiz() {
-      window.quizSubmitted = false;
-      userAnswers = {};
+   function resetQuiz() {
+     window.quizSubmitted = false;
+     userAnswers = {};
+      updateQuestionCount();
       generateQuiz();
       renderQuiz();
       document.getElementById('quiz-score').innerHTML = '';
     }
-    window.onload = () => { generateQuiz(); renderQuiz(); }
+    window.onload = () => { updateQuestionCount(); generateQuiz(); renderQuiz(); }
 
     function showTab(event, tabName) {
       document.querySelectorAll('.tab').forEach(e => e.classList.remove('active'));
@@ -218,3 +227,4 @@
       if (tabName !== "schema") closePanel();
     }
 
+}

--- a/index.html
+++ b/index.html
@@ -126,6 +126,17 @@
       </div>
       <!-- Quiz trắc nghiệm -->
       <div class="tab-content" id="quiz">
+        <div class="quiz-config">
+          <label for="question-count">Số câu hỏi:</label>
+          <select id="question-count" onchange="resetQuiz()">
+            <option value="10">10</option>
+            <option value="15">15</option>
+            <option value="20" selected>20</option>
+            <option value="25">25</option>
+            <option value="30">30</option>
+            <option value="40">40</option>
+          </select>
+        </div>
         <div class="quiz-container" id="quiz-area"></div>
         <div class="quiz-sticky-actions">
           <button class="quiz-action-btn" id="submit-btn" onclick="submitQuiz()">Nộp bài</button>

--- a/styles.css
+++ b/styles.css
@@ -122,6 +122,15 @@ body {
     margin-top: 30px;
 }
 
+.quiz-config {
+    margin-bottom: 15px;
+}
+
+.quiz-config select {
+    padding: 6px 10px;
+    border-radius: 6px;
+}
+
 .question {
     background: #fff;
     border-radius: 8px;


### PR DESCRIPTION
## Summary
- add dropdown to select number of questions
- show chosen question count in score
- regenerate quiz when selection changes
- style dropdown
- wrap JS in browser check so requiring the file under Node doesn't throw

## Testing
- `node --check app.js`
- `node -e "require('./app.js')"`


------
https://chatgpt.com/codex/tasks/task_e_68440e2ca6c0832ba959f8610836863c