### PR TITLE
Make quiz action buttons sticky

### DIFF
--- a/app.js
+++ b/app.js
@@ -85,6 +85,7 @@ function resetQuiz() {
     generateQuiz();
     renderQuiz();
     document.getElementById('quiz-score').innerHTML = '';
+    document.getElementById('quiz').scrollIntoView({behavior:'smooth'});
 }
 window.onload = () => { generateQuiz(); renderQuiz(); }
   const STAT_PANEL = {

--- a/index.html
+++ b/index.html
@@ -242,8 +242,10 @@
     <!-- Quiz trắc nghiệm -->
     <div class="tab-content" id="quiz">
       <div class="quiz-container" id="quiz-area"></div>
-      <button class="quiz-action-btn" id="submit-btn" onclick="submitQuiz()">Nộp bài</button>
-      <button class="quiz-action-btn" id="reset-btn" onclick="resetQuiz()">Làm lại</button>
+      <div class="quiz-footer">
+        <button class="quiz-action-btn" id="submit-btn" onclick="submitQuiz()">Nộp bài</button>
+        <button class="quiz-action-btn" id="reset-btn" onclick="resetQuiz()">Làm lại</button>
+      </div>
       <div id="quiz-score"></div>
     </div>
   </div>

--- a/styles.css
+++ b/styles.css
@@ -120,6 +120,7 @@
 
     .quiz-container {
       margin-top: 30px;
+      margin-bottom: 70px;
     }
 
     .question {
@@ -163,8 +164,19 @@
       border-radius: 20px;
       cursor: pointer;
       font-size: 1em;
-      margin: 18px 10px 0 0;
+      margin: 0 10px 0 0;
       transition: all .2s;
+    }
+
+    .quiz-footer {
+      position: sticky;
+      bottom: 0;
+      background: #fff;
+      padding: 10px 0;
+      display: flex;
+      gap: 10px;
+      box-shadow: 0 -2px 8px rgba(0,0,0,0.05);
+      z-index: 10;
     }
 
     .quiz-action-btn:disabled {


### PR DESCRIPTION
## Summary
- keep quiz submit/reset buttons visible while scrolling
- add bottom margin and sticky styles
- scroll to the quiz tab when resetting

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68445bea766c832ba280a9b46d47f571