### PR TITLE
Implement background dim when panels open

### DIFF
--- a/app.js
+++ b/app.js
@@ -13,6 +13,22 @@ if (typeof window !== 'undefined') {
     extra.style.display = (extra.style.display === 'block') ? 'none' : 'block';
     card.classList.toggle('active');
   }
+
+  function showOverlay() {
+    const ov = document.getElementById('overlay');
+    if (ov) ov.classList.add('active');
+  }
+
+  function hideOverlay() {
+    const ov = document.getElementById('overlay');
+    if (ov) ov.classList.remove('active');
+  }
+
+  function closeOverlay() {
+    hideOverlay();
+    closeSEPanel();
+    closeTestPanel();
+  }
   // QUIZ ENGINE
 let quizQuestions = [];
 let userAnswers = {};
@@ -268,9 +284,11 @@ function showTab(event, tabName) {
   function showTestPanel(key) {
     document.getElementById('stat-panel-content').innerHTML = `<h2 style="margin-top:0;font-size:1.25em">${STAT_PANEL[key].title}</h2>` + STAT_PANEL[key].html;
     document.getElementById('stat-panel').classList.add('open');
+    showOverlay();
   }
   function closeTestPanel() {
     document.getElementById('stat-panel').classList.remove('open');
+    hideOverlay();
   }
   const SE_PANEL = {
     "mota": {
@@ -367,9 +385,11 @@ function showTab(event, tabName) {
   function showSEPanel(key) {
     document.getElementById('se-panel-content').innerHTML = `<h2 style="margin-top:0;font-size:1.15em">${SE_PANEL[key].title}</h2>${SE_PANEL[key].html}`;
     document.getElementById('se-panel').classList.add('open');
+    showOverlay();
   }
   function closeSEPanel() {
     document.getElementById('se-panel').classList.remove('open');
+    hideOverlay();
   }
 
 

--- a/index.html
+++ b/index.html
@@ -271,6 +271,7 @@
 
     </div>
   </div>
+  <div id="overlay" class="overlay" onclick="closeOverlay()"></div>
   <script src="questions.js"></script>
   <script src="app.js"></script>
 </body>

--- a/styles.css
+++ b/styles.css
@@ -60,6 +60,24 @@
       box-shadow: 0 16px 32px rgba(52, 90, 182, 0.08);
     }
 
+    .overlay {
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100vw;
+      height: 100vh;
+      background: rgba(0, 0, 0, 0.45);
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity .3s;
+      z-index: 1100;
+    }
+
+    .overlay.active {
+      opacity: 1;
+      pointer-events: auto;
+    }
+
     .tab-content {
       display: none;
     }
@@ -283,7 +301,7 @@
       height: 100vh;
       background: #fff;
       border-left: 4px solid #3b4ef7;
-      z-index: 99;
+      z-index: 1101;
       box-shadow: -5px 0 36px #212b4a21;
       transition: right 0.37s cubic-bezier(.7, .13, .67, 1.2);
       padding-top: 24px;


### PR DESCRIPTION
## Summary
- add overlay element in `index.html`
- introduce overlay styles and increase panel z-index
- implement `showOverlay` and `hideOverlay` in `app.js`
- display overlay whenever a slide-out panel opens

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68446b3e024c832bb85dd7e694ec9958