### PR TITLE
Implement dynamic sidebar navigation

### DIFF
--- a/common.js
+++ b/common.js
@@ -30,4 +30,12 @@ if (typeof window !== 'undefined') {
     if (typeof closeTestPanel === "function") closeTestPanel();
   }
 
+  function loadPage(event, file) {
+    const container = document.querySelector('.content.main');
+    if (!container) return;
+    container.innerHTML = `<iframe src="${file}" class="page-frame"></iframe>`;
+    document.querySelectorAll('.page-link').forEach(btn => btn.classList.remove('active'));
+    if (event) event.target.classList.add('active');
+  }
+
 }

--- a/index.html
+++ b/index.html
@@ -11,10 +11,16 @@
 <body>
   <div class="layout">
   <div class="sidebar">
-          <div class="header">
-        <h1>📊 Thống kê Ứng dụng trong Tâm lý học</h1>
-        <p>Tổng quan, ví dụ thực tiễn & luyện tập trắc nghiệm – Chuẩn bị cho kiểm tra!</p>
-      </div>
+    <div class="header">
+      <h1>📊 Thống kê Ứng dụng trong Tâm lý học</h1>
+      <p>Tổng quan, ví dụ thực tiễn & luyện tập trắc nghiệm – Chuẩn bị cho kiểm tra!</p>
+    </div>
+    <div class="menu">
+      <button class="page-link" onclick="loadPage(event, '01_intro.html')">Giới thiệu</button>
+      <button class="page-link" onclick="loadPage(event, '02_descriptiveStat.html')">Thống kê mô tả</button>
+      <button class="page-link" onclick="loadPage(event, '03_test_1.html')">Chi Square &amp; T-test</button>
+    </div>
+    <hr>
     <div class="tabs">
       <button class="tab" onclick="showTab(event, 'cheatsheet')">Bảng Tham Chiếu</button>
       <button class="tab" onclick="showTab(event, 'examples')">Ví dụ thực tiễn</button>

--- a/styles.css
+++ b/styles.css
@@ -30,19 +30,19 @@
     }
 
     .header {
-      text-align: center;
+      text-align: left;
       margin-bottom: 40px;
       color: #ffffff;
     }
 
     .header h1 {
-      font-size: 1.5em;
+      font-size: 18px;
       margin-bottom: 8px;
       font-weight: 800;
     }
 
     .header p {
-      font-size: 0.88em;
+      font-size: 16px;
       opacity: 0.93;
     }
 
@@ -51,6 +51,33 @@
       flex-direction: column;
       gap: 10px;
       margin-top: 20px;
+    }
+
+    .menu {
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+      margin-top: 20px;
+    }
+
+    .page-link {
+      padding: 10px 18px;
+      width: 100%;
+      text-align: left;
+      background: transparent;
+      border: none;
+      border-radius: 6px;
+      border-left: 4px solid transparent;
+      color: #fff;
+      cursor: pointer;
+      font-weight: 600;
+      transition: background .2s;
+    }
+
+    .page-link:hover,
+    .page-link.active {
+      background: rgba(255,255,255,0.2);
+      border-left: 4px solid #f1fa8c;
     }
 
     .tab {
@@ -71,6 +98,12 @@
     .tab.active {
       background: rgba(255,255,255,0.2);
       border-left: 4px solid #f1fa8c;
+    }
+
+    .page-frame {
+      width: 100%;
+      min-height: 80vh;
+      border: none;
     }
 
     .content {


### PR DESCRIPTION
## Summary
- load standalone lessons in main content area
- style sidebar header and new lesson links
- add JavaScript helper to load lesson pages in an iframe

## Testing
- `npm test`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68458670ab04832bb9821c881d4ad04b