### PR TITLE
Fix restoring index tab content

### DIFF
--- a/common.js
+++ b/common.js
@@ -1,9 +1,19 @@
+let defaultMainHTML = '';
 if (typeof window !== 'undefined') {
+  const initContainer = document.querySelector('.content.main');
+  if (initContainer) defaultMainHTML = initContainer.innerHTML;
+
   function showTab(event, tabName) {
+    const container = document.querySelector('.content.main');
+    if (container && !document.getElementById(tabName)) {
+      container.innerHTML = defaultMainHTML;
+    }
+    document.querySelectorAll('.page-link').forEach(btn => btn.classList.remove('active'));
     document.querySelectorAll('.tab').forEach(e => e.classList.remove('active'));
     document.querySelectorAll('.tab-content').forEach(e => e.classList.remove('active'));
     if (event) event.target.classList.add('active');
-    document.getElementById(tabName).classList.add('active');
+    const target = document.getElementById(tabName);
+    if (target) target.classList.add('active');
     if (tabName === 'quiz') resetQuiz();
   }
 

--- a/styles.css
+++ b/styles.css
@@ -15,16 +15,13 @@
       padding: 20px;
       background: linear-gradient(180deg, #1d3557, #457b9d);
       color: #fff;
-      position: fixed;
-      top: 0;
-      bottom: 0;
-      left: 0;
+      height: 100vh;
       overflow-y: auto;
       box-shadow: 2px 0 6px rgba(0,0,0,0.1);
+      flex-shrink: 0;
     }
 
     .main {
-      margin-left: 240px;
       padding: 28px 24px;
       flex: 1;
     }


### PR DESCRIPTION
## Summary
- ensure the index tabs can be restored after loading a page
- keep sidebar in its own column via flex layout

## Testing
- `npm test`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684587e202f4832bb2617159e84db385