### PR TITLE
Improve sidebar and quiz dropdown

### DIFF
--- a/common.js
+++ b/common.js
@@ -11,7 +11,7 @@ if (typeof window !== 'undefined') {
     document.querySelectorAll('.page-link').forEach(btn => btn.classList.remove('active'));
     document.querySelectorAll('.tab').forEach(e => e.classList.remove('active'));
     document.querySelectorAll('.tab-content').forEach(e => e.classList.remove('active'));
-    if (event) event.target.classList.add('active');
+    if (event) event.currentTarget.classList.add('active');
     const target = document.getElementById(tabName);
     if (target) target.classList.add('active');
     if (tabName === 'quiz') resetQuiz();
@@ -45,7 +45,7 @@ if (typeof window !== 'undefined') {
     if (!container) return;
     container.innerHTML = `<iframe src="${file}" class="page-frame"></iframe>`;
     document.querySelectorAll('.page-link').forEach(btn => btn.classList.remove('active'));
-    if (event) event.target.classList.add('active');
+    if (event) event.currentTarget.classList.add('active');
   }
 
 }

--- a/index.html
+++ b/index.html
@@ -16,15 +16,15 @@
       <p>Tổng quan, ví dụ thực tiễn & luyện tập trắc nghiệm – Chuẩn bị cho kiểm tra!</p>
     </div>
     <div class="menu">
-      <button class="page-link" onclick="loadPage(event, '01_intro.html')">Giới thiệu</button>
-      <button class="page-link" onclick="loadPage(event, '02_descriptiveStat.html')">Thống kê mô tả</button>
-      <button class="page-link" onclick="loadPage(event, '03_test_1.html')">Chi Square &amp; T-test</button>
+      <button class="page-link sidebar-item" onclick="loadPage(event, '01_intro.html')">Giới thiệu</button>
+      <button class="page-link sidebar-item" onclick="loadPage(event, '02_descriptiveStat.html')">Thống kê mô tả</button>
+      <button class="page-link sidebar-item" onclick="loadPage(event, '03_test_1.html')">Chi Square &amp; T-test</button>
     </div>
     <hr>
     <div class="tabs">
-      <button class="tab" onclick="showTab(event, 'cheatsheet')">Bảng Tham Chiếu</button>
-      <button class="tab" onclick="showTab(event, 'examples')">Ví dụ thực tiễn</button>
-      <button class="tab" onclick="showTab(event, 'quiz')">Quiz trắc nghiệm</button>
+      <button class="tab sidebar-item" onclick="showTab(event, 'cheatsheet')">Bảng Tham Chiếu</button>
+      <button class="tab sidebar-item" onclick="showTab(event, 'examples')">Ví dụ thực tiễn</button>
+      <button class="tab sidebar-item" onclick="showTab(event, 'quiz')">Quiz trắc nghiệm</button>
     </div>
   </div>
 

--- a/quiz.js
+++ b/quiz.js
@@ -3,8 +3,9 @@ if (typeof window !== 'undefined') {
   let userAnswers = {};
   let numQuizQuestions = 20;
 
+
   // Ensure the dropdown includes an option for the maximum available questions
-  document.addEventListener('DOMContentLoaded', () => {
+  function ensureMaxOption() {
     const select = document.getElementById('numQuizQuestions');
     if (!select || typeof allQuestions === 'undefined') return;
     const max = allQuestions.length;
@@ -15,8 +16,13 @@ if (typeof window !== 'undefined') {
       opt.textContent = `${max} câu`;
       select.appendChild(opt);
     }
-  });
+  }
 
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', ensureMaxOption);
+  } else {
+    ensureMaxOption();
+  }
   function shuffleArray(arr) {
     for (let i = arr.length - 1; i > 0; i--) {
       const j = Math.floor(Math.random() * (i + 1));

--- a/styles.css
+++ b/styles.css
@@ -19,6 +19,9 @@
       overflow-y: auto;
       box-shadow: 2px 0 6px rgba(0,0,0,0.1);
       flex-shrink: 0;
+      position: sticky;
+      top: 0;
+      align-self: flex-start;
     }
 
     .main {
@@ -57,7 +60,7 @@
       margin-top: 20px;
     }
 
-    .page-link {
+    .sidebar-item {
       padding: 10px 18px;
       width: 100%;
       text-align: left;
@@ -71,31 +74,14 @@
       transition: background .2s;
     }
 
-    .page-link:hover,
-    .page-link.active {
+    .sidebar-item:hover,
+    .sidebar-item.active {
       background: rgba(255,255,255,0.2);
       border-left: 4px solid #f1fa8c;
     }
 
-    .tab {
-      padding: 10px 18px;
-      width: 100%;
-      text-align: left;
-      background: transparent;
-      border: none;
-      border-radius: 6px;
-      border-left: 4px solid transparent;
-      color: #fff;
-      cursor: pointer;
-      font-weight: 600;
-      transition: background .2s;
-    }
-
-    .tab:hover,
-    .tab.active {
-      background: rgba(255,255,255,0.2);
-      border-left: 4px solid #f1fa8c;
-    }
+    .page-link { }
+    .tab { }
 
     .page-frame {
       width: 100%;


### PR DESCRIPTION
## Summary
- keep sidebar fixed using CSS sticky
- unify sidebar button styling
- ensure active styling works consistently
- fix quiz dropdown to always add option for all questions

## Testing
- `npm test`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68458aff2f30832bb7a3086bf9b5a496