### PR TITLE
Fix max quiz question option

### DIFF
--- a/quiz.js
+++ b/quiz.js
@@ -105,6 +105,7 @@ if (typeof window !== 'undefined') {
   }
 
   function resetQuiz() {
+    ensureMaxOption();
     document.getElementById('quiz-area').style.display = 'none';
     document.getElementById('quiz-actions').style.display = 'none';
     document.getElementById('quiz-setup').style.display = '';


### PR DESCRIPTION
## Summary
- ensure the quiz dropdown always includes an option for all questions

## Testing
- `npm test`
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68458e2dc4c4832b8e293b635a0623f6