### PR TITLE
Add inline content option

### DIFF
--- a/common.js
+++ b/common.js
@@ -40,10 +40,14 @@ if (typeof window !== 'undefined') {
     if (typeof closeTestPanel === "function") closeTestPanel();
   }
 
-  function loadPage(event, file) {
+  function loadPage(event, file, samePage = false) {
     const container = document.querySelector('.content.main');
     if (!container) return;
-    container.innerHTML = `<iframe src="${file}" class="page-frame"></iframe>`;
+    if (samePage) {
+      container.innerHTML = defaultMainHTML;
+    } else if (file) {
+      container.innerHTML = `<iframe src="${file}" class="page-frame"></iframe>`;
+    }
     document.querySelectorAll('.page-link').forEach(btn => btn.classList.remove('active'));
     if (event) event.currentTarget.classList.add('active');
   }

--- a/index.html
+++ b/index.html
@@ -22,9 +22,9 @@
     </div>
     <hr>
     <div class="tabs">
-      <button class="tab sidebar-item" onclick="showTab(event, 'cheatsheet')">Bảng Tham Chiếu</button>
-      <button class="tab sidebar-item" onclick="showTab(event, 'examples')">Ví dụ thực tiễn</button>
-      <button class="tab sidebar-item" onclick="showTab(event, 'quiz')">Quiz trắc nghiệm</button>
+      <button class="tab sidebar-item" onclick="loadPage(event, '', true); showTab(event, 'cheatsheet')">Bảng Tham Chiếu</button>
+      <button class="tab sidebar-item" onclick="loadPage(event, '', true); showTab(event, 'examples')">Ví dụ thực tiễn</button>
+      <button class="tab sidebar-item" onclick="loadPage(event, '', true); showTab(event, 'quiz')">Quiz trắc nghiệm</button>
     </div>
   </div>
 


### PR DESCRIPTION
## Summary
- allow `loadPage` to reset to internal markup when needed
- connect tab buttons to the new parameter for loading built‑in content

## Testing
- `npm test`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68458f0643f4832bab0a510eccee5dca