### PR TITLE
Improve mobile sidebar

### DIFF
--- a/common.js
+++ b/common.js
@@ -38,6 +38,39 @@ if (typeof window !== 'undefined') {
     hideOverlay();
     if (typeof closeSEPanel === "function") closeSEPanel();
     if (typeof closeTestPanel === "function") closeTestPanel();
+    if (typeof closeSidebar === "function") closeSidebar();
+  }
+
+  function openSidebar() {
+    const sb = document.querySelector('.sidebar');
+    const btn = document.querySelector('.menu-btn');
+    if (sb) sb.classList.add('open');
+    if (btn) {
+      btn.classList.add('open');
+      btn.textContent = '✕';
+    }
+    showOverlay();
+  }
+
+  function closeSidebar() {
+    const sb = document.querySelector('.sidebar');
+    const btn = document.querySelector('.menu-btn');
+    if (sb) sb.classList.remove('open');
+    if (btn) {
+      btn.classList.remove('open');
+      btn.textContent = '☰';
+    }
+    hideOverlay();
+  }
+
+  function toggleSidebar() {
+    const sb = document.querySelector('.sidebar');
+    if (!sb) return;
+    if (sb.classList.contains('open')) {
+      closeSidebar();
+    } else {
+      openSidebar();
+    }
   }
 
   function loadPage(event, file, samePage = false) {
@@ -50,6 +83,7 @@ if (typeof window !== 'undefined') {
       }
       document.querySelectorAll('.sidebar a').forEach(a => a.classList.remove('active'));
       if (event) event.currentTarget.classList.add('active');
+      if (typeof closeSidebar === 'function') closeSidebar();
       return;
     }
 
@@ -62,6 +96,7 @@ if (typeof window !== 'undefined') {
     }
     document.querySelectorAll('.page-link').forEach(btn => btn.classList.remove('active'));
     if (event) event.currentTarget.classList.add('active');
+    if (typeof closeSidebar === 'function') closeSidebar();
   }
 
 }

--- a/common.js
+++ b/common.js
@@ -100,33 +100,21 @@ if (typeof window !== 'undefined') {
   }
 
 }
+
         function showSection(sectionId) {
-            // Ẩn tất cả sections
-            const sections = document.querySelectorAll('.section');
-            sections.forEach(section => {
-                if (section) {
-                    section.classList.remove('active');
-                }
-            });
-            
-            // Hiện section được chọn
+            const sections = document.querySelectorAll('.content-section, .section');
+            sections.forEach(section => section.classList.remove('active'));
+
             const targetSection = document.getElementById(sectionId);
-            if (targetSection) {
-                targetSection.classList.add('active');
-            }
-            
-            // Cập nhật tab active
-            const tabs = document.querySelectorAll('.tab');
-            tabs.forEach(tab => {
-                if (tab) {
-                    tab.classList.remove('active');
-                }
-            });
-            
-            // Tìm tab được click và set active
-            const clickedTab = event?.target;
-            if (clickedTab) {
-                clickedTab.classList.add('active');
+            if (targetSection) targetSection.classList.add('active');
+
+            const tabs = document.querySelectorAll('.nav-btn, .tab');
+            tabs.forEach(tab => tab.classList.remove('active'));
+
+            if (event?.currentTarget) event.currentTarget.classList.add('active');
+
+            if (sectionId === 'quiz' && typeof initializeQuiz === 'function' && !quizCompleted) {
+                initializeQuiz();
             }
         }
 
@@ -403,28 +391,6 @@ if (typeof window !== 'undefined') {
         let userAnswers = [];
         let quizCompleted = false;
 
-        function showSection(sectionId) {
-            // Hide all sections
-            document.querySelectorAll('.content-section').forEach(section => {
-                section.classList.remove('active');
-            });
-            
-            // Remove active class from all nav buttons
-            document.querySelectorAll('.nav-btn').forEach(btn => {
-                btn.classList.remove('active');
-            });
-            
-            // Show selected section
-            document.getElementById(sectionId).classList.add('active');
-            
-            // Add active class to clicked button
-            event.target.classList.add('active');
-            
-            // Initialize quiz if quiz section is selected
-            if (sectionId === 'quiz' && !quizCompleted) {
-                initializeQuiz();
-            }
-        }
 
         function calculateStats() {
             const input = document.getElementById('numbers').value;

--- a/index.html
+++ b/index.html
@@ -9,6 +9,8 @@
 </head>
 
 <body id="index">
+  <button class="menu-btn" onclick="toggleSidebar()">☰</button>
+  <div id="overlay" class="overlay" onclick="closeOverlay()"></div>
   <div class="layout">
     <div class="sidebar">
       <h2>THỐNG KÊ ỨNG DỤNG TRONG TÂM LÝ HỌC</h2>

--- a/styles.css
+++ b/styles.css
@@ -11,24 +11,71 @@
       padding: 0 !important;
     }
 
-    .layout {
-      display: flex;
-      min-height: 100vh;
-    }
+.layout {
+  display: flex;
+  min-height: 100vh;
+}
 
-    .sidebar {
-      width: 280px;
-      padding: 20px;
-      background: linear-gradient(180deg, #1d3557, #457b9d);
-      color: #fff;
-      height: 100vh;
-      overflow-y: auto;
-      box-shadow: 2px 0 6px rgba(0, 0, 0, 0.1);
-      flex-shrink: 0;
-      position: sticky;
-      top: 0;
-      align-self: flex-start;
-    }
+.menu-btn {
+  display: none;
+  position: fixed;
+  top: 15px;
+  left: 15px;
+  z-index: 1201;
+  background: #1d3557;
+  color: #fff;
+  border: none;
+  padding: 8px 12px;
+  border-radius: 4px;
+  font-size: 1.2em;
+  transition: left .3s;
+}
+
+
+.sidebar {
+  width: 280px;
+  padding: 20px;
+  background: linear-gradient(180deg, #1d3557, #457b9d);
+  color: #fff;
+  height: 100vh;
+  overflow-y: auto;
+  box-shadow: 2px 0 6px rgba(0, 0, 0, 0.1);
+  flex-shrink: 0;
+  position: sticky;
+  top: 0;
+  align-self: flex-start;
+}
+
+.sidebar.open {
+  left: 0;
+}
+
+@media (max-width:640px) {
+  .sidebar {
+    position: fixed;
+    left: -260px;
+    top: 0;
+    height: 100vh;
+    z-index: 1200;
+    transition: left .3s;
+  }
+
+  .content {
+    height: 100vh;
+  }
+
+  .layout {
+    flex-direction: column;
+  }
+
+  .menu-btn {
+    display: block;
+  }
+
+  .menu-btn.open {
+    left: 295px;
+  }
+}
 
     .sidebar h2 {
       font-size: 18px;


### PR DESCRIPTION
## Summary
- support slide-out sidebar on small screens
- hide sidebar after selecting a menu item
- move menu button with sidebar and switch to X icon when open

## Testing
- `npm test`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6846a2cbcbfc832ba8d844aa0c68fad2