### PR TITLE
Enhance sidebar toggle behaviour

### DIFF
--- a/common.js
+++ b/common.js
@@ -43,8 +43,26 @@ if (typeof window !== 'undefined') {
 
   function openSidebar() {
     const sb = document.querySelector('.sidebar');
+    const btn = document.querySelector('.menu-btn');
+    if (!sb) return;
+    sb.classList.add('open');
+    showOverlay();
+    if (btn) {
+      btn.classList.add('open');
+      btn.textContent = '✖';
+    }
+  }
 
-    if (sb) sb.classList.remove('open');
+  function closeSidebar() {
+    const sb = document.querySelector('.sidebar');
+    const btn = document.querySelector('.menu-btn');
+    if (!sb) return;
+    sb.classList.remove('open');
+    hideOverlay();
+    if (btn) {
+      btn.classList.remove('open');
+      btn.textContent = '☰';
+    }
   }
 
   function toggleSidebar() {

--- a/styles.css
+++ b/styles.css
@@ -28,6 +28,7 @@
   padding: 8px 12px;
   border-radius: 4px;
   font-size: 1.2em;
+  transition: left .3s;
 }
 .sidebar {
   width: 280px;
@@ -67,6 +68,10 @@
 
   .menu-btn {
     display: block;
+  }
+
+  .menu-btn.open {
+    left: 275px;
   }
 
 


### PR DESCRIPTION
## Summary
- improve sidebar toggle logic
- animate menu button with sidebar and show close icon

## Testing
- `pytest -q`
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846a9a7ca14832bbf222f3a812502be